### PR TITLE
Remove redundant dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,23 +34,18 @@
         <dependencies>
             <dependency>
                 <groupId>org.openjfx</groupId>
-                <artifactId>javafx-base</artifactId>
-                <version>11.0.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.openjfx</groupId>
-                <artifactId>javafx-swing</artifactId>
-                <version>11.0.2</version>
+                <artifactId>javafx-controls</artifactId>
+                <version>${openjfx.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-fxml</artifactId>
-                <version>11.0.2</version>
+                <version>${openjfx.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.openjfx</groupId>
-                <artifactId>javafx-controls</artifactId>
-                <version>11.0.2</version>
+                <artifactId>javafx-swing</artifactId>
+                <version>${openjfx.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>

--- a/sudoku-javafx/pom.xml
+++ b/sudoku-javafx/pom.xml
@@ -19,19 +19,15 @@
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-base</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-swing</artifactId>
+            <artifactId>javafx-fxml</artifactId>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-fxml</artifactId>
+            <artifactId>javafx-swing</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Both `javafx-controls` and `javafx-fxml` have a transitive dependency on `javafx-base`. Therefore it is not required for to be included explicitly in the list of dependencies.